### PR TITLE
Improved PKGBUILD + Added License file 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Crystal Linux
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,13 +1,14 @@
 pkgname=crystal-mirrorlist
 pkgver=0.1.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Crystal Linux Mirrorlist"
-arch=(any)
-url="https://github.com/crystal-linux/pkgbuild.$pkgname"
+arch=('any')
+url="https://github.com/crystal-linux-packages/${pkgname}"
 license=('MIT')
-source=('crystal-mirrorlist')
+source=("${pkgname}")
 sha256sums=('6ab56fd86a28599d7a6926c6036cfa86f0385a4a61dd59615eb642b9027bd84b')
 
 package () {
-    install -Dm755 crystal-mirrorlist "${pkgdir}/etc/pacman.d/crystal-mirrorlist"
+    install -Dm 644 "${pkgname}" "${pkgdir}/etc/pacman.d/${pkgname}"
+    install -Dm 644 "LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,8 +5,10 @@ pkgdesc="Crystal Linux Mirrorlist"
 arch=('any')
 url="https://github.com/crystal-linux-packages/${pkgname}"
 license=('MIT')
-source=("${pkgname}")
-sha256sums=('6ab56fd86a28599d7a6926c6036cfa86f0385a4a61dd59615eb642b9027bd84b')
+source=("${pkgname}"
+        "LICENSE")
+sha256sums=('6ab56fd86a28599d7a6926c6036cfa86f0385a4a61dd59615eb642b9027bd84b'
+            'd00321af957a776510ec3d7b5cc9316c50ab928f9231066b532ac8f0cf3ce69c')
 
 package () {
     install -Dm 644 "${pkgname}" "${pkgdir}/etc/pacman.d/${pkgname}"


### PR DESCRIPTION
Hi,

Some improvements for the PKGBUILD:

- Switched all vars to `${var}` format.
- Used the `${pkgname}` var instead of `crystal-mirrorlist`.
- Modified the `url` according to the new package GH org.
- Replaced the `755` permission to `644` for the `crystal-mirrorlist` file in the `package ()` function. It doesn't have to be executable AFAIK.
- Since, the `crystal-mirrorlist` is licensed under the MIT licence, the later has to be provided to the end user (see https://wiki.archlinux.org/title/PKGBUILD#license and the screenshot below). I created the MIT License file in the GH repo and added it to the `source` array (with its 256sum integrity check) and to the `package ()` function in the PKGBUILD. **That means it will have to be provided in the PKGBUILD working dir, just like the `crystal-mirrorlist` file**

![image](https://user-images.githubusercontent.com/53110319/193412327-24729f62-c7a4-4f8a-b3f1-11765bacd910.png)

What do you think?
